### PR TITLE
Update Fable.JS to Fable.Repl references

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -1,7 +1,7 @@
 let fableBranch = "master"
 let AppveyorReplArtifactURLParams = "?branch=" + fableBranch + "&pr=false"
 let AppveyorReplArtifactURL =
-    "https://ci.appveyor.com/api/projects/fable-compiler/Fable/artifacts/src/dotnet/Fable.JS/repl-bundle.zip"
+    "https://ci.appveyor.com/api/projects/fable-compiler/Fable/artifacts/src/dotnet/Fable.Repl/repl-bundle.zip"
     + AppveyorReplArtifactURLParams
 
 let FCSExportFolderName = "FSharp.Compiler.Service_export"
@@ -181,7 +181,7 @@ Target "GetBundleFromAppveyor" (fun _ ->
 
 // Assume the bundle has been built in a sibling Fable repo
 Target "GetBundleLocally" (fun _ ->
-    FileUtils.cp_r (currentDir </> "../fable/src/dotnet/Fable.JS/bundle") (currentDir </> "public/js/repl")
+    FileUtils.cp_r (currentDir </> "../fable/src/dotnet/Fable.Repl/bundle") (currentDir </> "public/js/repl")
 )
 
 Target "BuildLib" (fun _ ->

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -14,8 +14,8 @@ nuget Thoth.Json prerelease
 nuget Thoth.Elmish.Toast
 nuget Fable.PowerPack prerelease
 
-github fable-compiler/Fable:master src/dotnet/Fable.JS/Interfaces.fs
-github fable-compiler/Fable:master src/dotnet/Fable.JS/Metadata.fs
+github fable-compiler/Fable:master src/dotnet/Fable.Repl/Interfaces.fs
+github fable-compiler/Fable:master src/dotnet/Fable.Repl/Metadata.fs
 
 group Build
 framework: net46

--- a/paket.lock
+++ b/paket.lock
@@ -327,13 +327,13 @@ NUGET
       Fable.PowerPack (>= 1.5.1) - restriction: >= netstandard2.0
       Fable.React (>= 3.1.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5) - restriction: >= netstandard2.0
-    Thoth.Json (2.0.0-beta-004)
-      Fable.Core (>= 2.0.0-alpha-011) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5) - restriction: >= netstandard2.0
+    Thoth.Json (2.0.0-beta-005)
+      Fable.Core (>= 2.0.0-beta-001) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
 GITHUB
   remote: fable-compiler/Fable
-    src/dotnet/Fable.JS/Interfaces.fs (325c94de038a0bdd22220e416c809db7a3237ba2)
-    src/dotnet/Fable.JS/Metadata.fs (325c94de038a0bdd22220e416c809db7a3237ba2)
+    src/dotnet/Fable.Repl/Interfaces.fs (6b4638763e9709ca6cb5d11046961163bbfe1733)
+    src/dotnet/Fable.Repl/Metadata.fs (6b4638763e9709ca6cb5d11046961163bbfe1733)
 GROUP Build
 RESTRICTION: == net46
 NUGET

--- a/src/App/App.fsproj
+++ b/src/App/App.fsproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\fable-compiler\Fable\src\dotnet\Fable.JS\Interfaces.fs">
+    <Compile Include="..\..\paket-files\fable-compiler\Fable\src\dotnet\Fable.Repl\Interfaces.fs">
       <Paket>True</Paket>
       <Link>paket-files/Interfaces.fs</Link>
     </Compile>

--- a/src/App/Editor.fs
+++ b/src/App/Editor.fs
@@ -6,7 +6,7 @@ open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
 open Fable.PowerPack
-open Fable.JS
+open Fable.Repl
 
 let getEditorContent (ed: Monaco.Editor.IStandaloneCodeEditor) =
     ed.getModel().getValue(Monaco.Editor.EndOfLinePreference.TextDefined, true)
@@ -16,7 +16,7 @@ let getEditorContent (ed: Monaco.Editor.IStandaloneCodeEditor) =
 //---------------------------------------------------
 
 /// **Description**
-/// Convert `Fable.JS.Glyph` type into the `Monaco.Languages.CompletionItemKind`
+/// Convert `Fable.Repl.Glyph` type into the `Monaco.Languages.CompletionItemKind`
 /// **Parameters**
 ///   * `glyph` - parameter of type `Glyph`
 ///
@@ -48,7 +48,7 @@ let createCompletionProvider getCompletions =
                 let! completions = getCompletions position.lineNumber position.column lineText
                 return
                     completions
-                    |> Array.map (fun (c: Fable.JS.Completion) ->
+                    |> Array.map (fun (c: Fable.Repl.Completion) ->
                         jsOptions<Monaco.Languages.CompletionItem>(fun ci ->
                             ci.label <- c.Name
                             ci.kind <- convertGlyph c.Glyph

--- a/src/App/Main.fs
+++ b/src/App/Main.fs
@@ -65,7 +65,7 @@ type Msg =
     | LoadSuccess
     | LoadFail
     | UrlHashChange
-    | MarkEditorErrors of Fable.JS.Error[]
+    | MarkEditorErrors of Fable.Repl.Error[]
     | StartCompile of string option
     | EndCompile of Result<string, string>
     | ShareCode

--- a/src/App/Shared.fs
+++ b/src/App/Shared.fs
@@ -40,11 +40,11 @@ type WorkerRequest =
 type WorkerAnswer =
     | Loaded
     | LoadFailed
-    | ParsedCode of errors: Fable.JS.Error[]
-    | CompiledCode of jsCode: string * errors: Fable.JS.Error[]
+    | ParsedCode of errors: Fable.Repl.Error[]
+    | CompiledCode of jsCode: string * errors: Fable.Repl.Error[]
     | CompilationFailed of message: string
     | FoundTooltip of lines: string[]
-    | FoundCompletions of Fable.JS.Completion[]
+    | FoundCompletions of Fable.Repl.Completion[]
     static member Decoder =
         Decode.Auto.generateDecoder<WorkerAnswer>()
 

--- a/src/Worker/Worker.fs
+++ b/src/Worker/Worker.fs
@@ -3,7 +3,7 @@ module Fable.Repl.Worker
 open Fable.Core
 open Fable.Core.JsInterop
 open Fable.Import
-open Fable.JS
+open Fable.Repl
 open Shared
 
 let [<Global>] self: Browser.Worker = jsNative

--- a/src/Worker/Worker.fsproj
+++ b/src/Worker/Worker.fsproj
@@ -4,11 +4,11 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="..\..\paket-files\fable-compiler\Fable\src\dotnet\Fable.JS\Interfaces.fs">
+    <Compile Include="..\..\paket-files\fable-compiler\Fable\src\dotnet\Fable.Repl\Interfaces.fs">
       <Paket>True</Paket>
       <Link>paket-files/Interfaces.fs</Link>
     </Compile>
-    <Compile Include="..\..\paket-files\fable-compiler\Fable\src\dotnet\Fable.JS\Metadata.fs">
+    <Compile Include="..\..\paket-files\fable-compiler\Fable\src\dotnet\Fable.Repl\Metadata.fs">
       <Paket>True</Paket>
       <Link>paket-files/Metadata.fs</Link>
     </Compile>


### PR DESCRIPTION
Since the Fable repo renamed the Repl code from Fable.JS to Fable.Repl
the `GetBundleFromAppveyor` target has failed.

Updated all additional references to use the "Repl" version.

Should be OK to Complete once https://github.com/fable-compiler/Fable/pull/1556
has been merge.

Re-run the build after the other PR is merged to check everything is OK before merging
this one.