### PR TITLE
Use an array as parameter to Blob.Create

### DIFF
--- a/src/App/Generator.fs
+++ b/src/App/Generator.fs
@@ -92,7 +92,7 @@ type MimeType =
     | Css
 
 let generateBlobURL content mimeType : string =
-    let parts = [ content ] |> unbox<ResizeArray<obj>>
+    let parts = new ResizeArray<obj>([| content |])
     let options =
         jsOptions<BlobPropertyBag>(fun o ->
             o.``type`` <-


### PR DESCRIPTION
This fixes a bug that only triggered on Edge (Don't know by what miracle it worked on other browsers but it did)

Doesn't make edge work (yet) as it also need a change to Fable core lib.